### PR TITLE
icon fix

### DIFF
--- a/auth/assets/custom-icons/_data/custom-icons.json
+++ b/auth/assets/custom-icons/_data/custom-icons.json
@@ -181,8 +181,7 @@
     },
     {
       "title": "enom"   
-    },
-   
+    },   
     {
       "title": "Epic Games",
       "slug": "epic_games",
@@ -259,7 +258,7 @@
     {
       "title": "Itch",
       "slug": "itch_io",
-      "hex": "e7685e"
+      "hex": "000000"
     },
     {
       "title": "IVPN",


### PR DESCRIPTION
Fix itch.io icon color to more closely match usage from their site. Removed extra line after the "enom" entry

## Description

## Tests
